### PR TITLE
Update the Create Glob Tester link

### DIFF
--- a/docs/createrailwaysnavigator/other_topics/wildcards.md
+++ b/docs/createrailwaysnavigator/other_topics/wildcards.md
@@ -64,4 +64,4 @@ This means `Station 1`, and `Station 2` are valid selections for the Train.
 
 ## Additional Resources
 
-The [Create Glob Tester](https://tobi-blackscale.github.io/Create-Glob-Tester/6.0.5.html){ target="_blank" rel="nofollow" } can be used to create and test Glob Patterns for Create.
+The [Create Glob Tester](https://tobi-blackscale.github.io/Create-Glob-Tester/GlobRegExTest.html){ target="_blank" rel="nofollow" } can be used to create and test Glob Patterns for Create.


### PR DESCRIPTION
The wiki currently links to a specific page of the glob tester website instead of the homepage.
The creator of the site said in the create discord that he plans to rework the site which will change the structure of it. He did say though that the homepage link won't change.