### PR TITLE
make placeholders list easier to read and maintain

### DIFF
--- a/docs/createrailwaysnavigator/other_topics/placeholders.md
+++ b/docs/createrailwaysnavigator/other_topics/placeholders.md
@@ -25,17 +25,17 @@ These placeholders only work on assembled trains. For some of them, the train mu
 - `via` - a comma separated list of all stopovers
 - `line` - the train name or, if defined, the line name
 - `carriages` - the amount of carriages this train has
-- `origin.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
-- `destination.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
-- `next.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
-- `stopN.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
+- `origin.<option>` - see [Stopover options](#stopover-options) for options
+- `destination.<option>` - see [Stopover options](#stopover-options) for options
+- `next.<option>` - see [Stopover options](#stopover-options) for options
+- `stopN.<option>` - see [Stopover options](#stopover-options) for options
 
 ## Station placeholders
 
 These placeholders only work on displays in the world. For some of them, the train must also be in service.
 
-- `trainN.<subplaceholder>`, available subplaceholders are as follows:
-    - any subplaceholder under [Stopover subplaceholders](#stopover-subplaceholders)
+- `trainN.<option>`, available options are as follows:
+    - any option under [Stopover options](#stopover-options)
     - `via` - a comma separated list of all stopovers
     - `line` - the train name or, if defined, the line name
     - `origin` - where the train started its journey
@@ -45,19 +45,7 @@ These placeholders only work on displays in the world. For some of them, the tra
     - `delay_time` - the train delay as formatted text
     - `delay_reason` - the reason for the delay
 
-## Elevator placeholders
-
-These placeholders only work on elevators.
-
-- `elevator.<subplaceholder>`, available subplaceholders are as follows:
-    - `current.short` - short name of the current floor eg. `0`
-    - `current.long` - long name of the current floor eg. `Main Lobby`
-    - `destination.short` - short name of the floor the elevator is heading to, eg. `21`
-    - `destination.long` - long name of the floor the elevator is heading, eg. `Gym`
-    - `sign` - arrows indicating if the elevator is moving up or down
-    - `sign.triangle` - the same thing as above but using a different pair of characters.
-
-## Stopover subplaceholders
+## Stopover options
 
 - `station_name` - the arrival station
 - `platform` - the arrival platform number
@@ -65,3 +53,15 @@ These placeholders only work on elevators.
 - `departure` - departure time in in-game `hh:mm` format
 - `arrival_eta` - arrival time as an eta
 - `departure_eta` - departure time as an eta
+
+## Elevator placeholders
+
+These placeholders only work on elevators.
+
+- `elevator.<option>`, available options are as follows:
+    - `current.short` - short name of the current floor eg. `0`
+    - `current.long` - long name of the current floor eg. `Main Lobby`
+    - `destination.short` - short name of the floor the elevator is heading to, eg. `21`
+    - `destination.long` - long name of the floor the elevator is heading, eg. `Gym`
+    - `sign` - arrows indicating if the elevator is moving up or down
+    - `sign.triangle` - the same thing as above but using a different pair of characters.

--- a/docs/createrailwaysnavigator/other_topics/placeholders.md
+++ b/docs/createrailwaysnavigator/other_topics/placeholders.md
@@ -25,34 +25,17 @@ These placeholders only work on assembled trains. For some of them, the train mu
 - `via` - a comma separated list of all stopovers
 - `line` - the train name or, if defined, the line name
 - `carriages` - the amount of carriages this train has
-- `origin.` where the train started its journey **OR**
-
-    `destination.` where the train will end its journey **OR**
-
-    `next.` the next stop, includes the destination **OR**
-
-    `stopN.` the following stops, where `N=0` is the next stop, excludes the destination,
-    
-    followed by:
-
-    - `station_name` - the arrival station
-    - `platform` - the arrival platform number
-    - `arrival` - arrival time in in-game `hh:mm` format
-    - `departure` - departure time in in-game `hh:mm` format
-    - `arrival_eta` - arrival time as an eta
-    - `departure_eta` - departure time as an eta
+- `origin.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
+- `destination.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
+- `next.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
+- `stopN.<subplaceholder>` - see [Stopover subplaceholders](#stopover-subplaceholders) for subplaceholders
 
 ## Station placeholders
 
 These placeholders only work on displays in the world. For some of them, the train must also be in service.
 
-- `trainN.`, followed by:
-    - `station_name` - the arrival station
-    - `platform` - the arrival platform number
-    - `arrival` - arrival time in in-game `hh:mm` format
-    - `departure` - departure time in in-game `hh:mm` format
-    - `arrival_eta` - arrival time as an eta
-    - `departure_eta` - departure time as an eta
+- `trainN.<subplaceholder>`, available subplaceholders are as follows:
+    - any subplaceholder under [Stopover subplaceholders](#stopover-subplaceholders)
     - `via` - a comma separated list of all stopovers
     - `line` - the train name or, if defined, the line name
     - `origin` - where the train started its journey
@@ -66,10 +49,19 @@ These placeholders only work on displays in the world. For some of them, the tra
 
 These placeholders only work on elevators.
 
-- `elevator.` followed by:
+- `elevator.<subplaceholder>`, available subplaceholders are as follows:
     - `current.short` - short name of the current floor eg. `0`
     - `current.long` - long name of the current floor eg. `Main Lobby`
     - `destination.short` - short name of the floor the elevator is heading to, eg. `21`
     - `destination.long` - long name of the floor the elevator is heading, eg. `Gym`
     - `sign` - arrows indicating if the elevator is moving up or down
     - `sign.triangle` - the same thing as above but using a different pair of characters.
+
+## Stopover subplaceholders
+
+- `station_name` - the arrival station
+- `platform` - the arrival platform number
+- `arrival` - arrival time in in-game `hh:mm` format
+- `departure` - departure time in in-game `hh:mm` format
+- `arrival_eta` - arrival time as an eta
+- `departure_eta` - departure time as an eta


### PR DESCRIPTION
move subplaceholders handled by the handleStopover function to their own section as they are common amongst multiple placeholders

change "`destination.`, followed by..." to a less confusing "`destination.<subplaceholders>`, available subplaceholders..."